### PR TITLE
Remove org.eclipse.xtext project from classpath

### DIFF
--- a/io.typefox.traceexample.parent/io.typefox.traceexample/.classpath
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/.classpath
@@ -10,6 +10,5 @@
 	<classpathentry kind="src" path="src/test/xtend-gen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.xtext"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
From what I understand, having a reference to the org.eclipse.xtext
project this in the classpath only makes sense if you are also
developing xtext and have this project in your workspace.  In the common
case, however, we are going to use the xtext from the Eclipse
installation or that Gradle downloaded.