### PR TITLE
GH-2 Fixed classpath issues when importing projects into Eclipse with Gradle

### DIFF
--- a/io.typefox.traceexample.parent/.project
+++ b/io.typefox.traceexample.parent/.project
@@ -5,6 +5,11 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>

--- a/io.typefox.traceexample.parent/io.typefox.traceexample.ide/.project
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample.ide/.project
@@ -15,6 +15,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>

--- a/io.typefox.traceexample.parent/io.typefox.traceexample.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample.ide/.settings/org.eclipse.jdt.core.prefs
@@ -5,3 +5,4 @@ org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.builder.resourceCopyExclusionFilter=*.launch, *.xtend, *.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample.ide/src/main/resources/.gitignore
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample.ide/src/main/resources/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample.ide/src/main/xtend-gen/.gitignore
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample.ide/src/main/xtend-gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample.ide/src/main/xtext-gen/.gitignore
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample.ide/src/main/xtext-gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample/.classpath
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/.classpath
@@ -10,6 +10,5 @@
 	<classpathentry kind="src" path="src/test/xtend-gen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.xtext"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/io.typefox.traceexample.parent/io.typefox.traceexample/.project
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/.project
@@ -15,6 +15,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>

--- a/io.typefox.traceexample.parent/io.typefox.traceexample/.settings/org.eclipse.jdt.core.prefs
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/.settings/org.eclipse.jdt.core.prefs
@@ -5,3 +5,4 @@ org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.builder.resourceCopyExclusionFilter=*.launch, *.xtend, *.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample/src/main/resources/.gitignore
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/src/main/resources/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample/src/main/xtend-gen/.gitignore
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/src/main/xtend-gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample/src/main/xtext-gen/.gitignore
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/src/main/xtext-gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample/src/test/resources/.gitignore
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/src/test/resources/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample/src/test/xtend-gen/.gitignore
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/src/test/xtend-gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/io.typefox.traceexample.parent/io.typefox.traceexample/src/test/xtext-gen/.gitignore
+++ b/io.typefox.traceexample.parent/io.typefox.traceexample/src/test/xtext-gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
I have added .gitignore files to have the folders in git without content. So Gradle import wizard will not rewrite the .classpath.

Importing projects into Eclipse works and the import process does not generate any outgoing changes. After running the workflow no errors/warnings exist in the workspace. Running the Gradle build from both the command line and from Eclipse works fine.